### PR TITLE
Rename to swarmpal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.terminal.activateEnvInCurrentTerminal": true,
-    "python.pythonPath": "${env:CONDA_PREFIX}/envs/swarmx/bin/python",
+    "python.pythonPath": "${env:CONDA_PREFIX}/envs/swarmpal/bin/python",
     "python.testing.pytestArgs": [
         "tests"
     ],

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
-title: Swarm-DISC/SwarmX
+title: Swarm-DISC/SwarmPAL
 authors:
   - family-names: Smith
     given-names: Ashley R. A.
     orcid: https://orcid.org/0000-0001-5198-9574
-repository-code: "https://github.com/Swarm-DISC/SwarmX"
+repository-code: "https://github.com/Swarm-DISC/SwarmPAL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-See the [SwarmX development guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q) for development of this package. The following is provided from the template provided by Scikit-HEP
+See the [SwarmPAL development guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q) for development of this package. The following is provided from the template provided by Scikit-HEP
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SwarmX
+# SwarmPAL
 
 ⚠️ Warning: This package is under construction! ⚠️
 
@@ -14,24 +14,24 @@
 [![PyPI platforms][pypi-platforms]][pypi-link] -->
 
 
-[actions-badge]:            https://github.com/Swarm-DISC/SwarmX/workflows/CI/badge.svg
-[actions-link]:             https://github.com/Swarm-DISC/SwarmX/actions
+[actions-badge]:            https://github.com/Swarm-DISC/SwarmPAL/workflows/CI/badge.svg
+[actions-link]:             https://github.com/Swarm-DISC/SwarmPAL/actions
 [black-badge]:              https://img.shields.io/badge/code%20style-black-000000.svg
 [black-link]:               https://github.com/psf/black
-[conda-badge]:              https://img.shields.io/conda/vn/conda-forge/swarmx
-[conda-link]:               https://github.com/conda-forge/swarmx-feedstock
+[conda-badge]:              https://img.shields.io/conda/vn/conda-forge/swarmpal
+[conda-link]:               https://github.com/conda-forge/swarmpal-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
-[github-discussions-link]:  https://github.com/Swarm-DISC/SwarmX/discussions
-[gitter-badge]:             https://badges.gitter.im/https://github.com/Swarm-DISC/SwarmX/community.svg
-[gitter-link]:              https://gitter.im/https://github.com/Swarm-DISC/SwarmX/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
-[pypi-link]:                https://pypi.org/project/swarmx/
-[pypi-platforms]:           https://img.shields.io/pypi/pyversions/swarmx
-[pypi-version]:             https://badge.fury.io/py/swarmx.svg
-[rtd-badge]:                https://readthedocs.org/projects/swarmx/badge/?version=latest
-[rtd-link]:                 https://swarmx.readthedocs.io/en/latest/?badge=latest
+[github-discussions-link]:  https://github.com/Swarm-DISC/SwarmPAL/discussions
+[gitter-badge]:             https://badges.gitter.im/https://github.com/Swarm-DISC/SwarmPAL/community.svg
+[gitter-link]:              https://gitter.im/https://github.com/Swarm-DISC/SwarmPAL/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+[pypi-link]:                https://pypi.org/project/swarmpal/
+[pypi-platforms]:           https://img.shields.io/pypi/pyversions/swarmpal
+[pypi-version]:             https://badge.fury.io/py/swarmpal.svg
+[rtd-badge]:                https://readthedocs.org/projects/swarmpal/badge/?version=latest
+[rtd-link]:                 https://swarmpal.readthedocs.io/en/latest/?badge=latest
 [sk-badge]:                 https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
 
 
 ## Development
 
-See the [SwarmX development guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q)
+See the [SwarmPAL development guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,28 +1,28 @@
-swarmx modules
+swarmpal modules
 ==============
 
-swarmx.toolboxes.fac
+swarmpal.toolboxes.fac
 ^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: swarmx.toolboxes.fac
+.. automodule:: swarmpal.toolboxes.fac
     :members:
 
-swarmx.toolboxes.secs
+swarmpal.toolboxes.secs
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: swarmx.toolboxes.secs
+.. automodule:: swarmpal.toolboxes.secs
     :members:
 
-swarmx.io
+swarmpal.io
 ^^^^^^^^^
 
-.. autoclass:: swarmx.io.ExternalData
+.. autoclass:: swarmpal.io.ExternalData
     :members:
     :undoc-members:
     :show-inheritance:
     :inherited-members:
 
-.. autoclass:: swarmx.io.ViresDataFetcher
+.. autoclass:: swarmpal.io.ViresDataFetcher
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ from viresclient import set_token
 
 # -- Project information -----------------------------------------------------
 
-project = "swarmx"
+project = "swarmpal"
 copyright = "2022, Ashley Smith"
 author = "Ashley Smith"
 
@@ -61,11 +61,11 @@ html_theme = "sphinx_book_theme"
 
 html_title = f"{project}"
 
-html_baseurl = "https://swarmx.readthedocs.io/en/latest/"
+html_baseurl = "https://swarmpal.readthedocs.io/en/latest/"
 
 html_theme_options = {
     "home_page_in_toc": True,
-    "repository_url": "https://github.com/Swarm-DISC/swarmx",
+    "repository_url": "https://github.com/Swarm-DISC/swarmpal",
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 
-swarmx
+swarmpal
 ======
 
 This project is in the early planning stage.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,12 +2,12 @@
 
 The package is in early development so is not recommended for use yet. The following instructions are a guide how to set up for testing and evaluation. For development, see the [Development Guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q).
 
-(If you want to begin with a reasonable conda environment file, you can check [this one used for development](https://raw.githubusercontent.com/Swarm-DISC/SwarmX/staging/environment.yml))
+(If you want to begin with a reasonable conda environment file, you can check [this one used for development](https://raw.githubusercontent.com/Swarm-DISC/SwarmPAL/staging/environment.yml))
 
 Assuming you have a compatible system with git, a fortran compiler, and a Python>=3.8 installation with a recent version of pip, you can install the latest development version from the `staging` branch with:
 
 ```
-pip install git+https://github.com/Swarm-DISC/SwarmX@staging#egg=swarmx[dsecs]
+pip install git+https://github.com/Swarm-DISC/SwarmPAL@staging#egg=swarmpal[dsecs]
 ```
 
 The fortran compiler is required in order to install the dependency, apexpy. It may be better to try installing apexpy first and debugging that if you run into trouble.
@@ -15,5 +15,5 @@ The fortran compiler is required in order to install the dependency, apexpy. It 
 To bypass installation of apexpy (so disabling usage of the DSECS toolbox), you can use pip without the `[dsecs]` option:
 
 ```
-pip install git+https://github.com/Swarm-DISC/SwarmX@staging#egg=swarmx
+pip install git+https://github.com/Swarm-DISC/SwarmPAL@staging#egg=swarmpal
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-SwarmX is a Python package containing analysis and visualisation tools to interact with Swarm products. We rely on the VirES service (via [viresclient](https://viresclient.readthedocs.io/)) to provide access to data and models as well as frameworks from the Python ecosystem (e.g. Xarray) and specific utilities from the scientific community (e.g. apexpy).
+SwarmPAL is a Python package containing analysis and visualisation tools to interact with Swarm products. We rely on the VirES service (via [viresclient](https://viresclient.readthedocs.io/)) to provide access to data and models as well as frameworks from the Python ecosystem (e.g. Xarray) and specific utilities from the scientific community (e.g. apexpy).
 
 ![](https://mermaid.ink/img/pako:eNqFU9-L2zAM_leMH0bK2j7sMawHhZZxsO3KMsogyYNrq6mvsR0sO3flev_75PTX7caYIWDpkz5J_pQXLp0CnvPGi27Hvv6obGUZHYybk6t4Et78ytncivaAGtlP51o8BaWjtAcZtLND8sXbfyp7AlC2Gmyob4Bom15jNm8b53XYGfy88XdrjVG0GkXiwdFbGjaZ3B1XHibS2a1uogeVMrTtYsDjme6W0Am5LzG1_DzcRQN_FWez2WwAbwBIV5arQ9g5m9jJxAMGMHWd6v9RBay6vpHUCvosWz534ENKJA-NqzHgaMQm06F190jvw56c3x_fETVZVrhtoG5hqGobbQH8Nfeb0DbQl8B703nXw_Hc-DuRFiIINpcS8L_KrIsyW2u_LFgBvgefJ_YHC4z4VaROZ8yRFbQBhuA1DAoVcYPCdK22DfuQ6iKEQEbCvoAzorEQtGSGtqll0Is2DmIm_CN5PYwZTJspIxkfo5Unoeu3bQ1KD52lpPnq_sj6fyxRf9qKq16Kxg-HDmghVMzKxTA4i0jqJ_i7C7Bxbj9M8hB24C-7gfXoqiofcwPeCK3od3hJ7opTrIGK53RVsBWxDRWv7CuFxo6KwlLp4DzPt6JFGHMRgysOVvI8-AiXoIUWpJI5R73-BqYNJ6M)
 

--- a/docs/toolboxes/fac/using_fac.ipynb
+++ b/docs/toolboxes/fac/using_fac.ipynb
@@ -11,8 +11,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- The `swarmx.io` module contains the `MagData` class which provides access to the necessary data via `viresclient`\n",
-    "- The `swarmx.toolboxes.fac` module contains the `fac_single_sat` function which accepts data stored within a `MagData` object"
+    "- The `swarmpal.io` module contains the `MagData` class which provides access to the necessary data via `viresclient`\n",
+    "- The `swarmpal.toolboxes.fac` module contains the `fac_single_sat` function which accepts data stored within a `MagData` object"
    ]
   },
   {
@@ -23,7 +23,7 @@
    "source": [
     "import datetime as dt\n",
     "import numpy as np\n",
-    "from swarmx.toolboxes.fac import FacInputs, fac_single_sat"
+    "from swarmpal.toolboxes.fac import FacInputs, fac_single_sat"
    ]
   },
   {

--- a/docs/toolboxes/secs/using_secs.ipynb
+++ b/docs/toolboxes/secs/using_secs.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "import datetime as dt\n",
-    "from swarmx.toolboxes.secs import SecsInputs"
+    "from swarmpal.toolboxes.secs import SecsInputs"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or using methods built within SwarmX:"
+    "Or using methods built within SwarmPAL:"
    ]
   },
   {

--- a/docs/toolboxes/shared/data_io.ipynb
+++ b/docs/toolboxes/shared/data_io.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from swarmx.io import ExternalData, MagExternalData"
+    "from swarmpal.io import ExternalData, MagExternalData"
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 # Temporary environment configuration as a starting point
-name: swarmx
+name: swarmpal
 channels:
   - conda-forge
 dependencies:
@@ -27,7 +27,7 @@ dependencies:
   - sphinx-autobuild
   # Necessary for tqdm progress bars to work in vscode
   - ipywidgets
-  # Likely swarmx minimum dependencies
+  # Likely swarmpal minimum dependencies
   - cartopy=0.20.2
   - dask=2022.2.1
   - matplotlib=3.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 
 [project]
-name = "swarmx"
+name = "swarmpal"
 authors = [
     { name = "Ashley Smith", email = "ashley.smith@magneticearth.org" },
 ]
@@ -70,7 +70,7 @@ docs = [
 
 
 [project.urls]
-homepage = "https://github.com/Swarm-DISC/SwarmX"
+homepage = "https://github.com/Swarm-DISC/SwarmPAL"
 
 
 [tool.pytest.ini_options]

--- a/src/swarmpal/__init__.py
+++ b/src/swarmpal/__init__.py
@@ -1,4 +1,4 @@
-from swarmx import io, toolboxes
+from swarmpal import io, toolboxes
 
 __version__ = "0.1.0-a1"
 

--- a/src/swarmpal/io/__init__.py
+++ b/src/swarmpal/io/__init__.py
@@ -1,0 +1,3 @@
+from swarmpal.io._data_container import ExternalData, MagExternalData, ViresDataFetcher
+
+__all__ = ("ExternalData", "MagExternalData", "ViresDataFetcher")

--- a/src/swarmpal/io/_data_container.py
+++ b/src/swarmpal/io/_data_container.py
@@ -27,7 +27,7 @@ class ViresDataFetcher:
 
     Examples
     --------
-    >>> from swarmx.io import ViresDataFetcher
+    >>> from swarmpal.io import ViresDataFetcher
     >>> # Initialise request
     >>> v = ViresDataFetcher(
     >>>     parameters={
@@ -134,7 +134,7 @@ class ExternalData:
 
     Examples
     --------
-    >>> from swarmx.io import ExternalData
+    >>> from swarmpal.io import ExternalData
     >>> # Customise the class (if not using a subclass)
     >>> ExternalData.COLLECTIONS = [f"SW_OPER_MAG{x}_LR_1B" for x in "ABC"]
     >>> ExternalData.DEFAULTS["measurements"] = ["F", "B_NEC", "Flags_B"]

--- a/src/swarmpal/toolboxes/fac/__init__.py
+++ b/src/swarmpal/toolboxes/fac/__init__.py
@@ -1,4 +1,4 @@
-from swarmx.toolboxes.fac.fac_algorithms import (
+from swarmpal.toolboxes.fac.fac_algorithms import (
     FacInputs,
     fac_single_sat,
     fac_single_sat_algo,

--- a/src/swarmpal/toolboxes/fac/fac_algorithms.py
+++ b/src/swarmpal/toolboxes/fac/fac_algorithms.py
@@ -1,7 +1,7 @@
 """Tools to evaluate FACs using the single-satellite method
 
 Given input containing magnetic field measurements and model predictions
-(from swarmx.io.MagData), compute the FACs
+(from swarmpal.io.MagData), compute the FACs
 
 Adapted from code by Ask Neve Gamby (https://github.com/Swarm-DISC/SwarmPyFAC)
 
@@ -26,7 +26,7 @@ from numpy import (
 from numpy.linalg import norm
 from scipy.interpolate import splev, splrep
 
-from swarmx.io import ExternalData
+from swarmpal.io import ExternalData
 
 MU_0 = 4.0 * pi * 10 ** (-7)
 
@@ -158,7 +158,7 @@ def fac_single_sat(fac_inputs, **kwargs):
 
     Examples
     --------
-    >>> from swarmx.toolboxes.fac import FacInputs, fac_single_sat
+    >>> from swarmpal.toolboxes.fac import FacInputs, fac_single_sat
     >>> fac_inputs = FacInputs(
     >>>     collection="SW_OPER_MAGA_LR_1B", model="IGRF"
     >>>     start_time="2022-01-01", end_time="2022-01-02"

--- a/src/swarmpal/toolboxes/secs/__init__.py
+++ b/src/swarmpal/toolboxes/secs/__init__.py
@@ -1,0 +1,6 @@
+from swarmpal.toolboxes.secs.secs_inputs import SecsInputs, SecsInputSingleSat
+
+__all__ = (
+    "SecsInputSingleSat",
+    "SecsInputs",
+)

--- a/src/swarmpal/toolboxes/secs/secs_inputs.py
+++ b/src/swarmpal/toolboxes/secs/secs_inputs.py
@@ -2,7 +2,7 @@ from apexpy import Apex
 from numpy import cos, deg2rad, sin
 from pyproj import CRS, Transformer
 
-from swarmx.io import ExternalData
+from swarmpal.io import ExternalData
 
 
 class SecsInputSingleSat(ExternalData):

--- a/src/swarmx/io/__init__.py
+++ b/src/swarmx/io/__init__.py
@@ -1,3 +1,0 @@
-from swarmx.io._data_container import ExternalData, MagExternalData, ViresDataFetcher
-
-__all__ = ("ExternalData", "MagExternalData", "ViresDataFetcher")

--- a/src/swarmx/toolboxes/secs/__init__.py
+++ b/src/swarmx/toolboxes/secs/__init__.py
@@ -1,6 +1,0 @@
-from swarmx.toolboxes.secs.secs_inputs import SecsInputs, SecsInputSingleSat
-
-__all__ = (
-    "SecsInputSingleSat",
-    "SecsInputs",
-)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from xarray import Dataset
 
-from swarmx.io import ExternalData, MagExternalData, ViresDataFetcher
+from swarmpal.io import ExternalData, MagExternalData, ViresDataFetcher
 
 
 @pytest.mark.remote

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import swarmx as m
+import swarmpal as m
 
 
 def test_version():

--- a/tests/test_toolbox_fac.py
+++ b/tests/test_toolbox_fac.py
@@ -2,7 +2,7 @@ import datetime as dt
 
 import pytest
 
-from swarmx.toolboxes.fac import FacInputs, fac_single_sat
+from swarmpal.toolboxes.fac import FacInputs, fac_single_sat
 
 
 @pytest.mark.remote

--- a/tests/toolboxes/secs/test_secs_inputs.py
+++ b/tests/toolboxes/secs/test_secs_inputs.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pytest
 
 try:
-    from swarmx.toolboxes.secs import SecsInputs, SecsInputSingleSat
+    from swarmpal.toolboxes.secs import SecsInputs, SecsInputSingleSat
 except ImportError:
     pass
 


### PR DESCRIPTION
Renames all the swarmx/SwarmX references to swarmpal/SwarmPAL. The name of the project is SwarmPAL (Swarm Product Algorithm Laboratory, name inspired by biopal.org), while the actual Python package is `swarmpal` (matches the preferred style of modern Python).

Note that file locations change because of the package directory `src/swarmx` changing to `src/swarmpal`.

Since the package name is changed, this requires a change to the editable install in your dev environment. e.g., from within the `SwarmPAL` directory:
```
pip uninstall swarmx
pip install -e .[dsecs,dev,docs]
```

Still to do: equivalent changes in the secs/tfa branches