### PR TITLE
Fix issues with dependancies and unit tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,11 @@ dynamic = ["version"]
 
 dependencies = [
     "hapiclient >= 0.2.3",
-    "numpy >= 1.21",
+    "numpy >= 2.0.0",
     "matplotlib >= 3.5",
     "scipy >= 1.8",
     "viresclient >= 0.11",
-    "xarray >= 0.21",
-    "xarray-datatree >= 0.0.11",
+    "xarray >= 2024.10.0",
 ]
 
 [project.optional-dependencies]
@@ -59,6 +58,7 @@ test = [
 dev = [
     "pytest >=6",
     "nox >=2022",
+    "pre-commit",
 ]
 docs = [
     "Sphinx==7.2",
@@ -96,7 +96,6 @@ markers = [
     "remote",
     "dsecs",
 ]
-
 
 [tool.pycln]
 all = true

--- a/src/swarmpal/express/_pre_configured_runs.py
+++ b/src/swarmpal/express/_pre_configured_runs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datatree import DataTree
+from xarray import DataTree
 
 from swarmpal.express._configs import SPACECRAFT_TO_MAGLR_DATASET
 from swarmpal.io import PalDataItem, create_paldata

--- a/src/swarmpal/io/_paldata.py
+++ b/src/swarmpal/io/_paldata.py
@@ -11,9 +11,9 @@ from os import PathLike
 from re import match as regex_match
 
 from cdflib.xarray import xarray_to_cdf
-from datatree import DataTree, register_datatree_accessor
 from pandas import to_datetime as to_pandas_datetime
-from xarray import DataArray, Dataset
+from xarray import DataArray, Dataset, DataTree, register_datatree_accessor
+from xarray.core.extension_array import PandasExtensionArray
 
 from swarmpal.io._datafetchers import DataFetcherBase, get_fetcher
 from swarmpal.utils.exceptions import PalError
@@ -77,8 +77,8 @@ class PalDataItem:
 
     @property
     def datatree(self) -> DataTree:
-        """A datatree containing the dataset labelled with the dataset name"""
-        return DataTree(data=self.xarray, name=self.dataset_name)
+        """Create a new datatree containing only this dataset; labelled with the dataset name."""
+        return DataTree(dataset=self.xarray, name=self.dataset_name)
 
     @property
     def analysis_window(self) -> tuple[datetime]:
@@ -127,6 +127,11 @@ class PalDataItem:
         """Trigger the fetching of the data and attach PAL metadata"""
         self.xarray = self._fetcher.fetch_data()
         self.xarray.attrs["PAL_meta"] = self._serialise_pal_metadata()
+        # HOTFIX for https://github.com/ESA-VirES/VirES-Python-Client/issues/112
+        # Convert all instances of xarray.core.extension_array.PandasExtentionArray to numpy.ndarray
+        for var in self.xarray.variables:
+            if isinstance(self.xarray[var].data, PandasExtensionArray):
+                self.xarray[var].data = self.xarray[var].data.to_numpy()
 
     @staticmethod
     def _ensure_datetime(times: tuple[datetime | str]) -> tuple[datetime]:
@@ -403,17 +408,22 @@ def create_paldata(
     >>>     two=PalDataItem.from_vires(**data_params),
     >>> )
     """
+    children = {}
     # Assign each PalDataItem.datatree as a child in the tree
-    fulltree = DataTree(name="paldata")
     names = [pdi.dataset_name for pdi in paldataitems]
     if len(set(names)) != len(names):
         raise PalError("Duplicate dataset names found; use kwargs instead")
     for item in paldataitems:
         subtree = item.datatree
-        subtree.parent = fulltree
+        children[item.dataset_name] = subtree
     # Assign each PalDataItem.datatree in user-specified location
     for name, item in paldataitems_kw.items():
-        fulltree[f"{name}"] = item.datatree
+        children[f"{name}"] = item.datatree
+    # DataTree(children={'a/b': ...}) causes an infinite loop, but from_dict seems to work.
+    # See https://github.com/pydata/xarray/issues/9978
+    # fulltree = DataTree(name="paldata", children=children)
+    fulltree = DataTree.from_dict(children)
+    fulltree.name = "paldata"
     return fulltree
 
 

--- a/src/swarmpal/toolboxes/dsecs/processes.py
+++ b/src/swarmpal/toolboxes/dsecs/processes.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from apexpy import Apex
-from datatree import DataTree
 from numpy import cos, deg2rad, sin
 from pyproj import CRS, Transformer
+from xarray import DataTree
 
 from swarmpal.io import PalProcess
 from swarmpal.toolboxes.dsecs.dsecs_algorithms import _DSECS_steps

--- a/src/swarmpal/toolboxes/fac/processes.py
+++ b/src/swarmpal/toolboxes/fac/processes.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
-from datatree import DataTree, register_datatree_accessor
 from numpy import stack
-from xarray import Dataset
+from xarray import Dataset, DataTree, register_datatree_accessor
 
 from swarmpal.io import PalProcess
 from swarmpal.toolboxes.fac.fac_algorithms import fac_single_sat_algo
@@ -75,7 +74,7 @@ class FAC_single_sat(PalProcess):
         )
         ds_out["FAC"].attrs = {"units": "uA/m2"}
         ds_out["IRC"].attrs = {"units": "uA/m2"}
-        datatree["PAL_FAC_single_sat"] = DataTree(data=ds_out)
+        datatree["PAL_FAC_single_sat"] = DataTree(dataset=ds_out)
         return datatree
 
     def _validate(self):

--- a/src/swarmpal/toolboxes/tfa/processes.py
+++ b/src/swarmpal/toolboxes/tfa/processes.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from datatree import DataTree
-from xarray import DataArray, Dataset
+from xarray import DataArray, Dataset, DataTree
 
 from swarmpal.io import PalProcess
 from swarmpal.toolboxes.tfa import tfalib

--- a/tests/io/test_paldata.py
+++ b/tests/io/test_paldata.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from os.path import join as join_path
 
+import numpy as np
 import pytest
-from datatree import DataTree
 from pandas import to_datetime as to_pandas_datetime
-from xarray import Dataset, open_dataset
+from xarray import Dataset, DataTree, open_dataset
 
 from swarmpal.io._paldata import PalDataItem, create_paldata
 
@@ -27,8 +27,32 @@ def test_paldataitem_vires():
     )
     item = PalDataItem.from_vires(**vires_params)
     item.initialise()
+    # Type checks
     assert isinstance(item.xarray, Dataset)
     assert isinstance(item.datatree, DataTree)
+    assert isinstance(item.dataset_name, str)
+    # Sanity checks
+    # Collection
+    assert item.dataset_name == "SW_OPER_MAGA_LR_1B"
+    # Do we have all the expected variables?
+    assert len(item.xarray.keys()) == 8
+    assert "B_NEC_IGRF" in item.xarray
+    assert "Timestamp" in item.xarray
+    assert "Longitude" in item.xarray
+    assert "Latitude" in item.xarray
+    assert "Radius" in item.xarray
+    assert "B_NEC" in item.xarray
+    assert "NEC" in item.xarray
+    assert "F" in item.xarray
+    # Time interval matches [start,end]_time
+    assert item.xarray["Timestamp"].to_numpy()[0] >= np.datetime64(
+        "2016-01-01T00:00:00"
+    )
+    assert item.xarray["Timestamp"].to_numpy()[-1] <= np.datetime64(
+        "2016-01-01T00:00:10"
+    )
+    # Every entry in 'Spacecraft' should be 'A'
+    assert np.all(np.unique(item.xarray["Spacecraft"]) == ["A"])
     return item.xarray
 
 
@@ -56,8 +80,24 @@ def test_paldataitem_hapi():
     )
     item = PalDataItem.from_hapi(**hapi_params)
     item.initialise()
+    # Type checks
     assert isinstance(item.xarray, Dataset)
     assert isinstance(item.datatree, DataTree)
+    assert isinstance(item.dataset_name, str)
+    # Sanity checks
+    # Collection
+    assert item.dataset_name == "SW_OPER_MAGA_LR_1B"
+    # Do we have all the expected variables?
+    assert len(item.xarray.keys()) == 2
+    assert "B_NEC" in item.xarray
+    assert "F" in item.xarray
+    # Time interval matches [start,end]_time
+    assert item.xarray["Timestamp"].to_numpy()[0] >= np.datetime64(
+        "2016-01-01T00:00:00"
+    )
+    assert item.xarray["Timestamp"].to_numpy()[-1] <= np.datetime64(
+        "2016-01-01T00:00:10"
+    )
 
 
 def test_paldataitem_file(xarray_data_file):
@@ -159,9 +199,12 @@ def paldata_item_MAGB():
 def test_create_paldata(paldata_item_MAGA, paldata_item_MAGB):
     # Test basic paldata
     data = create_paldata(paldata_item_MAGA)
+    assert isinstance(data, DataTree)
     assert data.name == "paldata"
     assert "SW_OPER_MAGA_LR_1B" in data.children
     assert data.swarmpal.pal_meta["SW_OPER_MAGA_LR_1B"]
+    assert isinstance(paldata_item_MAGA.datatree, DataTree)
+    # assert not paldata_item_MAGA.datatree == data
     # Test paldata with two entries
     data = create_paldata(paldata_item_MAGA, paldata_item_MAGB)
     assert data.name == "paldata"
@@ -179,5 +222,8 @@ def test_create_paldata(paldata_item_MAGA, paldata_item_MAGB):
     assert data.name == "paldata"
     assert data["path1/alpha"]
     assert data["path2/bravo"]
+    # assert isinstance(data["path1/alpha"], DataTree)
+    # assert data["path1/alpha"].name == "SW_OPER_MAGA_LR_1B"
+    # assert isinstance(data["path2/bravo"], DataTree)
     assert data.swarmpal.pal_meta["path1/alpha"]
     assert data.swarmpal.pal_meta["path2/bravo"]

--- a/tests/io/test_palprocess.py
+++ b/tests/io/test_palprocess.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from datatree import DataTree
-from xarray import Dataset
+from xarray import Dataset, DataTree
 
 from swarmpal.io._paldata import PalDataItem, PalProcess, create_paldata
 
@@ -44,7 +43,8 @@ def test_palprocess(paldata_MAGA):
             dataset = subtree.ds
             parameter = self.config.get("parameter")
             # Apply the algorithm
-            output_data = dataset[parameter].diff(dim="Timestamp")
+            # Diff dataset[parameter].diff(dim="Timestamp")
+            output_data = dataset[parameter]
             # Create an output dataset
             data_out = Dataset(
                 data_vars={
@@ -52,7 +52,7 @@ def test_palprocess(paldata_MAGA):
                 }
             )
             # Write the output into a new path in the datatree and return it
-            subtree["output"] = DataTree(data=data_out)
+            subtree["output"] = DataTree(dataset=data_out)
             return datatree
 
     p = MyProcess(config={"dataset": "SW_OPER_MAGA_LR_1B", "parameter": "B_NEC"})


### PR DESCRIPTION
Replace xarray-contrib/datatree with xarray.DataTree.

xarray-datatree is no longer maintained and merged into xarray proper. SwarmPAL now useses the latest version of xarray. The API in xarray.DataTree is not the same as xarray-datatree.DataTree which required slight changes in how PalData objects were contstructed and updated unit tests.

Add work around ESA-VirES/VirES-Python-Client#114

Fix unit test for PalProcess