### PR TITLE
Extend PalDataItem.from_file to accept both CDF and netCDF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "hapiclient >= 0.2.3",
     "numpy >= 2.0.0",
     "matplotlib >= 3.5",
+    "pycdfpp >= 0.7",
     "scipy >= 1.8",
     "viresclient >= 0.11",
     "xarray >= 2024.10.0",

--- a/src/swarmpal/io/_cdf_interface.py
+++ b/src/swarmpal/io/_cdf_interface.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from viresclient._data_handling import FileReader
+
+
+def cdf_to_xarray(cdf_file):
+    with open(cdf_file, "rb") as f:
+        with FileReader(f) as fr:
+            return fr.as_xarray_dataset()

--- a/src/swarmpal/io/_cdf_interface.py
+++ b/src/swarmpal/io/_cdf_interface.py
@@ -1,9 +1,82 @@
 from __future__ import annotations
 
+import logging
+
+import pycdfpp
 from viresclient._data_handling import FileReader
+from xarray import Dataset
+
+logger = logging.getLogger(__name__)
 
 
-def cdf_to_xarray(cdf_file):
+def cdf_to_xarray_viresclient(
+    cdf_file,
+):
+    """Using viresclient FileReader"""
     with open(cdf_file, "rb") as f:
         with FileReader(f) as fr:
             return fr.as_xarray_dataset()
+
+
+def cdf_to_xarray(cdf_file):
+    """Using pycdfpp"""
+    cdf = pycdfpp.load(str(cdf_file))
+    timevars = ("Timestamp",)  # NB hardcoded for now, but should be made flexible
+    ds = Dataset()
+    # Add all the variables
+    for varname, data in cdf.items():
+        timevar = timevars[0]
+        num_dims = len(data.shape)
+        cdf_type = data.type
+        dim_names = [timevar] + [f"{varname}_dim_{i}" for i in range(1, num_dims)]
+        if str(cdf_type).endswith("CDF_EPOCH"):
+            ds[varname] = dim_names, pycdfpp.to_datetime64(data)
+        else:
+            ds[varname] = dim_names, data
+        attrs = {}
+        for _, attr in dict(data.attributes).items():
+            attrs[attr.name] = attr.value
+        ds[varname].attrs = attrs
+    # Add global attributes
+    for attr_name, attr_value in cdf.attributes.items():
+        _attr_value = attr_value[0] if len(attr_value) == 1 else list(attr_value)
+        ds.attrs[attr_name] = _attr_value
+    return ds
+
+
+def xarray_to_cdf(ds, file_name):
+    cdf = pycdfpp.CDF()
+    # Global attributes
+    for attr_name, attr_value in ds.attrs.items():
+        _attr_value = [attr_value] if not isinstance(attr_value, list) else attr_value
+        try:
+            cdf.add_attribute(attr_name, _attr_value)
+        except Exception as e:
+            logger.warning(f"Error adding attribute {attr_name}: {e}")
+    # # Coordinates
+    # for var_name, var_data in ds.coords.items():
+    #     cdf.add_variable(var_name, var_data.values, compression=pycdfpp.CompressionType.gzip_compression)
+    #     for attr_name, attr_value in var_data.attrs.items():
+    #         cdf[var_name].add_attribute(attr_name, attr_value)
+    # Only add Timestamp coordinate (typically the only coordinate in the dataset)
+    # Fix Timestamp to CDF_EPOCH to match source data
+    cdf.add_variable(
+        "Timestamp",
+        ds["Timestamp"].values,
+        pycdfpp.DataType.CDF_EPOCH,
+        compression=pycdfpp.CompressionType.gzip_compression,
+    )
+    # Data variables
+    for var_name, var_data in ds.data_vars.items():
+        _var_data = var_data.astype("str") if var_name == "Spacecraft" else var_data
+        try:
+            cdf.add_variable(
+                var_name,
+                _var_data.values,
+                compression=pycdfpp.CompressionType.gzip_compression,
+            )
+            for attr_name, attr_value in _var_data.attrs.items():
+                cdf[var_name].add_attribute(attr_name, attr_value)
+        except Exception as e:
+            logger.warning(f"Error adding variable {var_name}: {e}")
+    pycdfpp.save(cdf, file_name)

--- a/src/swarmpal/io/_datafetchers.py
+++ b/src/swarmpal/io/_datafetchers.py
@@ -236,6 +236,7 @@ class NetCDFfileDataFetcher(DataFetcherBase):
             raise FileNotFoundError(self.parameters.filename)
 
     def fetch_data(self) -> Dataset:
+        # filename_or_obj and group are kwargs for xarray.open_dataset
         kwargs = {"filename_or_obj": self.parameters.filename}
         if self.parameters.group:
             kwargs["group"] = self.parameters.group
@@ -243,7 +244,7 @@ class NetCDFfileDataFetcher(DataFetcherBase):
         try:
             ds.attrs["Sources"]
         except KeyError:
-            ds.attrs["Sources"] = [Path(kwargs["cdf_file"]).name]
+            ds.attrs["Sources"] = [Path(self.parameters.filename).name]
         return ds
 
 
@@ -267,11 +268,11 @@ class CDFfileDataFetcher(DataFetcherBase):
 
     def fetch_data(self) -> Dataset:
         kwargs = {"cdf_file": self.parameters.filename}
-        ds = cdf_to_xarray(kwargs["cdf_file"])
+        ds = cdf_to_xarray(**kwargs)
         try:
             ds.attrs["Sources"]
         except KeyError:
-            ds.attrs["Sources"] = [Path(kwargs["cdf_file"]).name]
+            ds.attrs["Sources"] = [Path(self.parameters.filename).name]
         return ds
 
 

--- a/src/swarmpal/io/_datafetchers.py
+++ b/src/swarmpal/io/_datafetchers.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from os import PathLike
 from os.path import exists as path_exists
+from pathlib import Path
 
 from hapiclient import hapi, hapitime2datetime
 from numpy.typing import ArrayLike
@@ -238,7 +239,12 @@ class NetCDFfileDataFetcher(DataFetcherBase):
         kwargs = {"filename_or_obj": self.parameters.filename}
         if self.parameters.group:
             kwargs["group"] = self.parameters.group
-        return open_dataset(**kwargs)
+        ds = open_dataset(**kwargs)
+        try:
+            ds.attrs["Sources"]
+        except KeyError:
+            ds.attrs["Sources"] = [Path(kwargs["cdf_file"]).name]
+        return ds
 
 
 class CDFfileDataFetcher(DataFetcherBase):
@@ -261,7 +267,12 @@ class CDFfileDataFetcher(DataFetcherBase):
 
     def fetch_data(self) -> Dataset:
         kwargs = {"cdf_file": self.parameters.filename}
-        return cdf_to_xarray(kwargs["cdf_file"])
+        ds = cdf_to_xarray(kwargs["cdf_file"])
+        try:
+            ds.attrs["Sources"]
+        except KeyError:
+            ds.attrs["Sources"] = [Path(kwargs["cdf_file"]).name]
+        return ds
 
 
 class ManualDataFetcher(DataFetcherBase):

--- a/src/swarmpal/io/_paldata.py
+++ b/src/swarmpal/io/_paldata.py
@@ -406,7 +406,7 @@ class PalDataTreeAccessor:
             {
                 "CREATOR": versions,
                 "CREATED": dt.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "TITLE": Path(filename.name),
+                "TITLE": Path(filename).name,
                 "PAL_meta": PalMeta.serialise(pal_meta),
             }
         )

--- a/tests/io/test_datafetchers.py
+++ b/tests/io/test_datafetchers.py
@@ -7,10 +7,11 @@ from swarmpal.io._datafetchers import HapiDataFetcher, ViresDataFetcher, get_fet
 
 
 def test_get_fetcher():
-    get_fetcher("vires")
-    get_fetcher("hapi")
-    get_fetcher("file")
-    get_fetcher("manual")
+    get_fetcher("ViresDataFetcher")
+    get_fetcher("HapiDataFetcher")
+    get_fetcher("NetCDFfileDataFetcher")
+    get_fetcher("CDFfileDataFetcher")
+    get_fetcher("ManualDataFetcher")
 
 
 @pytest.mark.remote()


### PR DESCRIPTION
An earlier attempt at this used [FileReader from within viresclient](https://github.com/ESA-VirES/VirES-Python-Client/blob/11e2c44dd209514fd3284cdbdb64da9b2ece689c/src/viresclient/_data_handling.py#L84)  to handle the conversion from cdf to xarray dataset, which was written to play nice with Swarm files. Due to that routine not fully loading everything from a file (i.e. all the global attributes) and being opinionated about adding extra coordinates (e.g. NEC), and problems using cdflib.xarray utilities, I started writing new `cdf_to_xarray` and `xarray_to_cdf` routines here which use pycdfpp instead.

I extended `PalDataItem.from_file` so that the file type is detected from the extension, or can be overridden  with the `filetype` option, and will use those `cdf_to_xarray` underneath.

```python
from swarmpal.io import PalDataItem, create_paldata

data = create_paldata(
    **{"MSS1A_TEST_VFM_L2_MAG_SCI-LR": PalDataItem.from_file(
        "MSS-VFM/MSS1A_TEST_VFM_L2_MAG_SCI-LR_20240101T000000_20240101T235959_V0418.cdf",
    )}
)
```

Similarly, the `.swarmpal.to_cdf` datatree accessor is updated to use the new pycdfpp-based `xarray_to_cdf`

```python
data.swarmpal.to_cdf(
    filename="MSS-VFM/test-output.cdf",
    leaf="MSS1A_TEST_VFM_L2_MAG_SCI-LR",
)
```

Should add tests to cover both NetCDF and CDF file reading and writing and round-trips. Not everything will be preserved so maybe that's something that should be improved.

This will need more work.