### PR TITLE
Add CLI option to override start and end times for datasets.

### DIFF
--- a/src/swarmpal/cli/commands.py
+++ b/src/swarmpal/cli/commands.py
@@ -1,18 +1,51 @@
 from __future__ import annotations
 
+import sys
+
 import click
 import yaml
 
 import swarmpal
 from swarmpal.express import fac_single_sat as _fac_single_sat
+from swarmpal.schema import is_iso8601_datetime
 from swarmpal.utils.configs import SPACECRAFT_TO_MAGLR_DATASET
 from swarmpal.utils.queries import last_available_time as _last_available_time
 
 
-def _read_config(filename):
+def _update_times(start_time, end_time, dataset_config):
+    """Helper to update start and end times in a dataset configuration."""
+    if not is_iso8601_datetime(start_time):
+        click.echo(
+            f"The start time should be in ISO8601 format. Got '{start_time}' instead.",
+            err=True,
+        )
+        sys.exit(1)
+    if not is_iso8601_datetime(end_time):
+        click.echo(
+            f"The end time should be in ISO8601 format. Got '{end_time}' instead.",
+            err=True,
+        )
+        sys.exit(1)
+
+    for dataset in dataset_config["data_params"]:
+        # Vires format
+        if "start_time" in dataset:
+            dataset["start_time"] = start_time
+        if "end_time" in dataset:
+            dataset["end_time"] = end_time
+        # HAPI format
+        if "start" in dataset:
+            dataset["start"] = start_time
+        if "stop" in dataset:
+            dataset["stop"] = end_time
+
+
+def _read_config(filename, times):
     """Helper function to read and validate YAML config files"""
     with open(filename) as f:
         datasets = yaml.safe_load(f)
+    if times is not None:
+        _update_times(times[0], times[1], datasets)
     return datasets
 
 
@@ -52,12 +85,18 @@ def last_available_time(collection):
 
 
 @cli.command(add_help_option=True, short_help="Fetch datasets from Vires or Hapi")
+@click.option(
+    "--time",
+    nargs=2,
+    type=str,
+    help="Override the start and end times in the configuration file",
+)
 @click.argument("config", type=click.File("r"))
 @click.argument("out", type=click.File("w"))
-def fetch_data(config, out):
+def fetch_data(time, config, out):
     """Fetch data described in yaml file CONFIG and save the resulting DataTree in NetCDF file OUT"""
 
-    dataset_config = _read_config(config.name)
+    dataset_config = _read_config(config.name, time)
     data = swarmpal.fetch_data(dataset_config)
     data.to_netcdf(out.name)
 
@@ -67,13 +106,19 @@ def fetch_data(config, out):
     short_help="Process datasets in batch mode",
     # help="Process datasets in batch mode for a given CONFIG file in yaml format",
 )
+@click.option(
+    "--time",
+    nargs=2,
+    type=str,
+    help="Override the start and end times in the configuration file",
+)
 @click.argument("config", type=click.File("r"))
 @click.argument("out", type=click.File("w"))
-def batch(config: click.File, out: click.Path):
+def batch(time, config: click.File, out: click.Path):
     """Run SwarmPAL in batch mode. The datasets and processes need to be specified in YAML file and
     passed as the first CONFIG argument. The results are written to NetCDF files specified by OUT."""
 
-    dataset_config = _read_config(config.name)
+    dataset_config = _read_config(config.name, time)
     data = swarmpal.fetch_data(dataset_config)
 
     # Apply processes

--- a/src/swarmpal/schema.py
+++ b/src/swarmpal/schema.py
@@ -152,17 +152,21 @@ definitions:
 fetch_data_schema = safe_load(fetch_data_schema_txt)
 
 
+def is_iso8601_datetime(instance):
+    try:
+        datetime.datetime.fromisoformat(instance)
+        return True
+    except ValueError:
+        return False
+
+
 def validate(config):
     """Validates config against the schema for fetch_data"""
     format_checker = jsonschema.FormatChecker()
 
     @format_checker.checks("iso8601-date-time")
-    def is_iso8601_datetime(instance):
-        try:
-            datetime.datetime.fromisoformat(instance)
-            return True
-        except ValueError:
-            return False
+    def _is_iso8601_datetime(instance):
+        return is_iso8601_datetime(instance)
 
     @format_checker.checks("timedelta")
     def is_timedelta(instance):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
+import numpy as np
 import pytest
+import xarray as xr
+import yaml
 from click.testing import CliRunner
 
 from swarmpal.cli import cli
+from swarmpal.cli.commands import _update_times
 
 # Unit tests for swarmpal.cli using the click library's recommendation at
 #  https://click.palletsprojects.com/en/stable/testing/
@@ -107,6 +111,9 @@ def test_cli_fetch_data(cli_runner, tmp_path):
         assert result.exit_code == 0, _format_cmd_non_zero_message(cmd_args)
         assert os.path.exists(output_filename)
 
+        ds = xr.open_datatree(output_filename)
+        assert "Spacecraft" in ds["/SW_OPER_MAGA_LR_1B"]
+
 
 @pytest.mark.remote()
 def test_cli_batch(cli_runner, tmp_path):
@@ -122,3 +129,117 @@ def test_cli_batch(cli_runner, tmp_path):
         result = cli_runner.invoke(cli, cmd_args)
         assert result.exit_code == 0, _format_cmd_non_zero_message(cmd_args)
         assert os.path.exists(output_filename)
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [
+        ("a", "b"),
+        ("2016-01-01T00:00:00", "b"),
+        ("a", "2016-01-01T00:00:00"),
+    ],
+)
+def test_update_times_fails(start_time, end_time, cli_runner, tmp_path):
+    output_filename = "output.nc4"
+    input_filename = "input.yaml"
+    cmd_args = [
+        "batch",
+        "--time",
+        start_time,
+        end_time,
+        input_filename,
+        output_filename,
+    ]
+
+    with cli_runner.isolated_filesystem(tmp_path):
+        with open(input_filename, "w") as f:
+            f.write(test_yaml_data_params)
+
+        result = cli_runner.invoke(cli, cmd_args)
+        assert "time should be in ISO8601 format." in result.output
+        assert result.exit_code == 1
+
+
+test_yaml_data_params_multiple = """
+data_params:
+  - provider: vires
+    collection: "SW_OPER_MAGA_LR_1B"
+    measurements: ["B_NEC"]
+    models: ["Model = CHAOS"]
+    auxiliaries: ["QDLat"]
+    start_time: "2016-03-18T11:00:00"
+    end_time: "2016-03-18T11:30:00"
+    server_url: https://vires.services/ows
+  - provider: vires
+    collection: SW_OPER_MAGC_LR_1B
+    measurements: ["B_NEC"]
+    models: ["Model = CHAOS"]
+    auxiliaries: ["QDLat"]
+    start_time: "2016-03-18T11:00:00"
+    end_time: "2016-03-18T11:30:00"
+    server_url: https://vires.services/ows
+"""
+test_yaml_data_params_hapi = """
+data_params:
+  - provider: hapi
+    dataset: "SW_OPER_MAGA_LR_1B"
+    parameters: "F,B_NEC"
+    start: "2016-01-01T00:00:00"
+    stop: "2016-01-01T00:00:10"
+    server: "https://vires.services/hapi"
+"""
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time", "config_content"),
+    [
+        ("2017-01-01T00:00:00", "2017-01-01T00:30:00", test_yaml_data_params),
+        ("2023-01-01T00:00:00", "2023-01-01T00:30:00", test_yaml_data_params_multiple),
+        ("2022-01-01T00:00:00", "2022-01-01T00:30:00", test_yaml_data_params_hapi),
+    ],
+)
+def test_cli_update_times_helper(start_time, end_time, config_content):
+    datasets = yaml.safe_load(config_content)
+    _update_times(start_time, end_time, datasets)
+    for dataset in datasets["data_params"]:
+        if dataset["provider"] == "vires":
+            assert dataset["start_time"] == start_time
+            assert dataset["end_time"] == end_time
+        if dataset["provider"] == "hapi":
+            assert dataset["start"] == start_time
+            assert dataset["stop"] == end_time
+
+
+@pytest.mark.remote()
+@pytest.mark.parametrize(
+    ("start_time", "end_time", "config_content"),
+    [
+        ("2017-01-01T00:00:00", "2017-01-01T00:30:00", test_yaml_data_params),
+        ("2023-01-01T00:00:00", "2023-01-01T00:30:00", test_yaml_data_params_multiple),
+        ("2022-01-01T00:00:00", "2022-01-01T00:30:00", test_yaml_data_params_hapi),
+    ],
+)
+def test_cli_update_times(start_time, end_time, config_content, cli_runner, tmp_path):
+    output_filename = "output.nc4"
+    input_filename = "input.yaml"
+    cmd_args = [
+        "fetch-data",
+        "--time",
+        start_time,
+        end_time,
+        input_filename,
+        output_filename,
+    ]
+
+    with cli_runner.isolated_filesystem(tmp_path):
+        with open(input_filename, "w") as f:
+            f.write(config_content)
+
+        result = cli_runner.invoke(cli, cmd_args)
+        assert result.exit_code == 0, result.output
+
+        ds = xr.open_datatree(output_filename)
+        for dataset in ds.children:
+            timestamps = ds[dataset]["Timestamp"].to_numpy()
+            assert np.all(np.datetime64(start_time) <= timestamps)
+            assert np.all(np.datetime64(end_time) >= timestamps)


### PR DESCRIPTION
The `swarmpal batch` and `swarmpal fetch-data` CLI commands now have a `--time` flag that can be used to override start and end times for datasets.

Example:
```bash
swarmpal batch --time 2023-01-01T00:00:00 2023-01-01T00:30:00 config.yaml result.nc4
ncdump -h result.nc4
```

With `config.yaml`:
```yaml
data_params:
  - provider: vires
    collection: "SW_OPER_MAGA_LR_1B"
    measurements: ["B_NEC"]
    models: ["CHAOS"]
    start_time: "2016-01-01T00:00:00"
    end_time: "2016-01-01T00:30:00"
    server_url: "https://vires.services/ows"
```


The `Timestamp` now starts at a time shortly after `2023-01-01T00:00:00` instead of `2016-01-01T00:00:00`:
```
int64 Timestamp(Timestamp) ;
	Timestamp:description = "Time stamp" ;
	Timestamp:units = "seconds since 2023-01-01 00:00:00" ;
	Timestamp:calendar = "proleptic_gregorian" ;
```