### PR TITLE
Add h5netcdf as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dynamic = ["version"]
 dependencies = [
     "click >= 8.1",
     "hapiclient >= 0.2.3",
+    "h5netcdf >= 1.6",
     "jsonschema >= 4.0.0",
     "numpy >= 1.26",
     "matplotlib >= 3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dynamic = ["version"]
 dependencies = [
     "click >= 8.1",
     "hapiclient >= 0.2.3",
-    "h5netcdf >= 1.6",
     "jsonschema >= 4.0.0",
     "numpy >= 1.26",
     "matplotlib >= 3.5",
@@ -45,7 +44,7 @@ dependencies = [
     "pyyaml >= 6.0.0",
     "scipy >= 1.8",
     "viresclient >= 0.11",
-    "xarray >= 2024.10.0",
+    "xarray[io] >= 2024.10.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
CI was failing on Python 3.11, which could be a regression introduced by [xarray v2025.08.0](https://docs.xarray.dev/en/stable/whats-new.html#v2025-08-0-august-14-2025). Installing h5netcdf fixes this, and might anyway be a better default engine to use.