### PR TITLE
Add file reading for CLI interface and experimental process

### DIFF
--- a/src/swarmpal/_api.py
+++ b/src/swarmpal/_api.py
@@ -64,6 +64,13 @@ def make_process(process_name=None, config={}):
 
             processes_by_name["TFA_WaveDetection"] = TFA_WaveDetection
 
+        elif process_name == "EXP_LocalForwardMagneticModel":
+            from swarmpal.experimental import LocalForwardMagneticModel
+
+            processes_by_name[
+                "EXP_LocalForwardMagneticModel"
+            ] = LocalForwardMagneticModel
+
         else:
             raise ValueError(
                 f"Unknown process {process_name}. Must be one of ['FAC_single_sat', 'DSECS_Preprocess', 'DSECS_Analysis']"
@@ -133,6 +140,19 @@ def _fetch_dataset(provider="", config={}, options=None):
                 * - `hapi`
                   - `dict(logging=False)`
     """
+    if provider == "file":
+        # TODO:
+        #  check that the file exists.
+        #  check that all required config keys are present.
+        return create_paldata(
+            **{
+                config["dataset"]: PalDataItem.from_file(
+                    filename=config["filename"],
+                    filetype=config["filetype"],
+                )
+            }
+        )
+
     # Convert pad_times from strings to timedelta objects
     if "pad_times" in config:
         config["pad_times"] = [_str_to_timedelta(time) for time in config["pad_times"]]
@@ -147,7 +167,7 @@ def _fetch_dataset(provider="", config={}, options=None):
         return create_paldata(PalDataItem.from_hapi(options=options, **config))
 
     raise ValueError(
-        f"Unknown provider {provider}. Provider must be one of ['vires', 'hapi']."
+        f"Unknown provider {provider}. Provider must be one of ['vires', 'hapi', 'file']."
     )
 
 

--- a/src/swarmpal/schema.py
+++ b/src/swarmpal/schema.py
@@ -14,6 +14,7 @@ properties:
       anyOf:
         - $ref: "#/definitions/vires_data_params"
         - $ref: "#/definitions/hapi_data_params"
+        - $ref: "#/definitions/file_data_params"
     description: "List of data parameter objects, each conforming to either vires_data_params or hapi_data_params."
   process_params:
     type: array
@@ -32,6 +33,7 @@ properties:
             - TFA_Filter
             - TFA_Wavelet
             - TFA_WaveDetection
+            - EXP_LocalForwardMagneticModel
     description: "List of parameter objects, each describing a SwarmPal process that will be applied to the dataset"
 required:
   - data_params
@@ -147,6 +149,27 @@ definitions:
       - server
     additionalProperties: false
     description: "Schema for HAPI data parameters configuration."
+  file_data_params:
+    type: object
+    properties:
+
+      provider:
+        type: string
+        description: "Data provider name."
+        enum:
+          - "file"
+      filename:
+        type: string
+        description: "Name of the file to be included in the DataTree"
+      filetype:
+        type: string
+        description: "File format."
+        enum:
+          - "cdf"
+          - "netcdf"
+      dataset:
+        type: string
+        description: "Name of the dataset in the resulting DataTree"
 """
 
 fetch_data_schema = safe_load(fetch_data_schema_txt)


### PR DESCRIPTION
Add a few features to SwarmPAL needed to continue with SwarmPAL-processor

 * Add the ability to use files with the CLI workflow.
 * Add the `LocalFowardMagneticModel` to the CLI workflow

The following config file will run the FAC toolbox on the associated file:

```yaml
---
data_params:
  - provider: file
    dataset: "SW_OPER_MAGA_LR_1B"
    filename: "SW_OPER_MAGA_LR_1B_20131126T000000_20131126T235959_0602_MDR_MAG_LR.cdf"
    filetype: cdf
process_params:
  - process_name: EXP_LocalForwardMagneticModel
    dataset: "SW_OPER_MAGA_LR_1B"
    model_descriptor: "CHAOS-Core"
  - process_name: FAC_single_sat
    dataset: SW_OPER_MAGA_LR_1B
    model_varname: B_NEC_CHAOS-Core
    measurement_varname: B_NEC
    time_jump_limit: 1
```